### PR TITLE
Fix improper Expanded usage

### DIFF
--- a/edu_academy/lib/MobileView/in&upPages/StudentMobileSignUpPage.dart
+++ b/edu_academy/lib/MobileView/in&upPages/StudentMobileSignUpPage.dart
@@ -31,10 +31,9 @@ class _StudentMobileSignUpPageState extends State<StudentMobileSignUpPage> {
         backgroundColor: const Color.fromARGB(255, 255, 255, 255),
         body: ListView(
           children: [
-            Expanded(
+            Container(
+              height: 250,
               child: Container(
-                height: 250,
-                child: Container(
                   decoration: BoxDecoration(
                       gradient: LinearGradient(
                           begin: Alignment.bottomLeft,
@@ -108,7 +107,6 @@ class _StudentMobileSignUpPageState extends State<StudentMobileSignUpPage> {
                   ),
                 ),
               ),
-            ),
             Padding(padding: EdgeInsets.only(top: 40)),
             Container(
               color: const Color.fromARGB(255, 255, 255, 255),

--- a/edu_academy/lib/MobileView/in&upPages/TeacherSignUpPage.dart
+++ b/edu_academy/lib/MobileView/in&upPages/TeacherSignUpPage.dart
@@ -21,10 +21,9 @@ class _TeacherSignUpPageState extends State<TeacherSignUpPage> {
         backgroundColor: const Color.fromARGB(255, 255, 255, 255),
         body: ListView(
           children: [
-            Expanded(
+            Container(
+              height: 250,
               child: Container(
-                height: 250,
-                child: Container(
                   decoration: BoxDecoration(
                       gradient: LinearGradient(
                           begin: Alignment.bottomLeft,
@@ -98,7 +97,6 @@ class _TeacherSignUpPageState extends State<TeacherSignUpPage> {
                   ),
                 ),
               ),
-            ),
             Expanded(child:Container()),
             Expanded(
               child: Container(


### PR DESCRIPTION
## Summary
- remove `Expanded` wrappers inside sign up pages that broke layout

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c65529408325a9f3504c27d02ddd